### PR TITLE
Fix issue where bucketname was always the same

### DIFF
--- a/tools/industry-toolkit/toolkit/stack.py
+++ b/tools/industry-toolkit/toolkit/stack.py
@@ -14,6 +14,8 @@ from aws_cdk import (
     Names
 )
 from constructs import Construct
+import uuid
+
 
 class IndustryToolkitStack(Stack):
     def __init__(self, scope: Construct, id: str, **kwargs) -> None:
@@ -37,7 +39,7 @@ class IndustryToolkitStack(Stack):
             description="Name of the role the CodeBuild pipeline will use. This role will be created."
         )
 
-        random_suffix = Names.unique_id(self)[:4].lower()
+        random_suffix = str(uuid.uuid4())[:4].lower()
         artifacts_bucket_name_param = CfnParameter(self, "ArtifactsBucketName",
             type="String",
             default=f"industry-toolkit-artifacts-bucket-{random_suffix}",


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/industry-toolkit/issues/56

*Description of changes:*
Fixed bucket name suffix to be random

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
